### PR TITLE
画面遷移の改善/firebaseからデータを取得後titleを一覧表示

### DIFF
--- a/lib/create_entry.dart
+++ b/lib/create_entry.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutterapp/main.dart';
 import 'package:intl/intl.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 //import 'diary.dart';
@@ -50,9 +51,14 @@ class _CreateEntryState extends State<CreateEntry> {
               FlatButton(
                 child: Icon(Icons.add_circle),
                 onPressed: (){
-                  print("before");
                   createDiary(titleText, articleText);
-                  print("after");
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) {
+                        return (MyHomePage());
+                      },
+                    ),
+                  );
                 },
               )
             ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutterapp/create_entry.dart';
@@ -31,10 +32,13 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  static final String strDate = DateFormat('yyyy-MM-dd - kk:mm').format(DateTime.now());
-  static String content = """hello world apple banana cake desert egg folk gorilla
+  static final String strDate =
+      DateFormat('yyyy-MM-dd - kk:mm').format(DateTime.now());
+  static String content =
+      """hello world apple banana cake desert egg folk gorilla
   hoge hage house icon json kaggle lemon monkey nallow option parse question relation\
   station tuition union various wrong xenophobia young zero""";
+
   List<Diary> diaries = [
     Diary(strDate, "title", content),
   ];
@@ -45,22 +49,36 @@ class _MyHomePageState extends State<MyHomePage> {
       appBar: AppBar(
         title: Text("comfortable diary"),
       ),
-      body: Center(
-        child: ListView.builder(
-            itemCount: diaries.length,
-            itemBuilder: (_, index) => ListTile(
-                  title: Text(diaries[index].title),
-                  subtitle: Text(diaries[index].createdAt),
-                  onTap: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (context) {
-                          return DiaryDetail(diaries[index]);
-                        },
-                      ),
-                    );
-                  }
-                )),
+      body: StreamBuilder(
+        stream: Firestore.instance.collection('diaries').snapshots(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return (Text('Loading data..'));
+          }
+          return Center(
+            child: ListView.builder(
+              itemCount: snapshot.data.documents.length,
+              itemBuilder: (_, index) => ListTile(
+                title: Text(snapshot.data.documents[index]["title"]),
+
+//                  timestampはstringじゃないので一旦停止
+//                subtitle: Text(snapshot.data.documents[index]["createdAt"]),
+
+//                diaryclassと連携できないため画面遷移を停止
+//                onTap: () {
+//                  Navigator.of(context).push(
+//                    MaterialPageRoute(
+//                      builder: (context) {
+//                        return DiaryDetail(diaries[index]);
+//                      },
+//                    ),
+//                  );
+//                },
+
+              ),
+            ),
+          );
+        },
       ),
       floatingActionButton: FloatingActionButton(
         child: Icon(Icons.add),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,15 +14,6 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // Try running your application with "flutter run". You'll see the
-        // application has a blue toolbar. Then, without quitting the app, try
-        // changing the primarySwatch below to Colors.green and then invoke
-        // "hot reload" (press "r" in the console where you ran "flutter run",
-        // or simply save your changes to "hot reload" in a Flutter IDE).
-        // Notice that the counter didn't reset back to zero; the application
-        // is not restarted.
         primarySwatch: Colors.blue,
       ),
       home: MyHomePage(title: 'a'),
@@ -79,10 +70,10 @@ class _MyHomePageState extends State<MyHomePage> {
             MaterialPageRoute(
               builder: (context) {
                 return CreateEntry();
-                //画面遷移ここまで
               },
             ),
           );
+          //画面遷移ここまで
         },
       ), // This trailing comma makes auto-formatting nicer for build methods.
     );


### PR DESCRIPTION
・create_entryのページでエントリーを作成後メイン画面に戻るよう仕様変更

・StreamBuilderを使って、firebaseから取得したデータのタイトルのみ一覧表示できるようにした
　課題
timestampをサブタイトルとして表示したい
各エントリーの詳細ページに画面遷移できるようにしたい